### PR TITLE
Use default `wp_insert_post` behavior for `post_date`

### DIFF
--- a/features/post-generate.feature
+++ b/features/post-generate.feature
@@ -172,3 +172,17 @@ Feature: Generate new WordPress posts
       """
       2000-01-01 02:11:00
       """
+
+  Scenario: Generating posts when the site timezone is ahead of UTC
+    When I run `wp option update timezone_string "Europe/Helsinki"`
+    And I run `wp post delete 1 --force`
+
+    When I run `wp post list --field=post_status`
+    Then STDOUT should be empty
+    
+    When I run `wp post generate --count=1`
+    And I run `wp post list --field=post_status`
+    Then STDOUT should be:
+      """
+      publish
+      """

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -766,11 +766,13 @@ class Post_Command extends CommandWithDBObject {
 
 		// Handle edge cases for how WP handle dates on wp_insert_post for older versions. If one of the values is empty, it's assigned to the current time. We need to avoid sending an empty value.
 		if ( ! empty( $post_data['post_date'] ) && empty( $post_data['post_date_gmt'] ) ) {
-			$post_data['post_date_gmt'] = get_gmt_from_date( $post_data['post_date'] );
+			$only_date = strlen($post_data['post_date']) === 10;
+			$post_data['post_date_gmt'] = get_gmt_from_date( $post_data['post_date'], $only_date ? 'Y-m-d' : 'Y-m-d H:i:s' );
 		}
 
 		if ( ! empty( $post_data['post_date_gmt'] ) && empty( $post_data['post_date'] ) ) {
-			$post_data['post_date'] = get_date_from_gmt( $post_data['post_date_gmt'] );
+			$only_date = strlen($post_data['post_date_gmt']) === 10;
+			$post_data['post_date'] = get_date_from_gmt( $post_data['post_date_gmt'], $only_date ? 'Y-m-d' : 'Y-m-d H:i:s' );
 		}
 
 		if ( ! post_type_exists( $post_data['post_type'] ) ) {

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -765,11 +765,11 @@ class Post_Command extends CommandWithDBObject {
 		$post_data['post_date_gmt'] = $this->maybe_convert_hyphenated_date_format( $post_data['post_date_gmt'] );
 
 		// Handle edge cases for how WP handle dates on wp_insert_post for older versions. If one of the values is empty, it's assigned to the current time. We need to avoid sending an empty value.
-		if ( isset( $post_data['post_date'] ) && empty( $post_data['post_date_gmt'] ) ) {
+		if ( ! empty( $post_data['post_date'] ) && empty( $post_data['post_date_gmt'] ) ) {
 			$post_data['post_date_gmt'] = get_gmt_from_date( $post_data['post_date'] );
 		}
-		
-		if ( isset( $post_data['post_date_gmt'] ) && empty( $post_data['post_date'] ) ) {
+
+		if ( ! empty( $post_data['post_date_gmt'] ) && empty( $post_data['post_date'] ) ) {
 			$post_data['post_date'] = get_date_from_gmt( $post_data['post_date_gmt'] );
 		}
 

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -761,7 +761,7 @@ class Post_Command extends CommandWithDBObject {
 
 		$post_data = array_merge( $defaults, $assoc_args );
 
-		$post_data['post_date'] 	= $this->maybe_convert_hyphenated_date_format( $post_data['post_date'] );
+		$post_data['post_date']     = $this->maybe_convert_hyphenated_date_format( $post_data['post_date'] );
 		$post_data['post_date_gmt'] = $this->maybe_convert_hyphenated_date_format( $post_data['post_date_gmt'] );
 
 		if ( ! post_type_exists( $post_data['post_type'] ) ) {
@@ -1002,10 +1002,10 @@ class Post_Command extends CommandWithDBObject {
 
 	/**
 	 * Convert a date-time string with a hyphen separator to a space separator.
-	 * 
+	 *
 	 * @param string $date_string The date-time string to convert.
 	 * @return string The converted date-time string.
-	 * 
+	 *
 	 * Example:
 	 * maybe_convert_hyphenated_date_format( "2018-07-05-17:17:17" );
 	 * Returns: "2018-07-05 17:17:17"

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -761,6 +761,9 @@ class Post_Command extends CommandWithDBObject {
 
 		$post_data = array_merge( $defaults, $assoc_args );
 
+		$post_data['post_date'] 	= $this->maybe_convert_hyphenated_date_format( $post_data['post_date'] );
+		$post_data['post_date_gmt'] = $this->maybe_convert_hyphenated_date_format( $post_data['post_date_gmt'] );
+
 		if ( ! post_type_exists( $post_data['post_type'] ) ) {
 			WP_CLI::error( "'{$post_data['post_type']}' is not a registered post type." );
 		}
@@ -995,5 +998,23 @@ class Post_Command extends CommandWithDBObject {
 		} else {
 			WP_CLI::halt( 1 );
 		}
+	}
+
+	/**
+	 * Convert a date-time string with a hyphen separator to a space separator.
+	 * 
+	 * @param string $dateString The date-time string to convert.
+	 * @return string The converted date-time string.
+	 * 
+	 * Example:
+	 * maybeConvertHyphenatedDateFormat("2018-07-05-17:17:17");
+	 * Returns: "2018-07-05 17:17:17"
+	 */
+	private function maybe_convert_hyphenated_date_format($dateString) {
+		// Check if the date string matches the format with the hyphen between date and time
+		if (preg_match('/^(\d{4}-\d{2}-\d{2})-(\d{2}:\d{2}:\d{2})$/', $dateString, $matches)) {
+			return $matches[1] . ' ' . $matches[2];
+		}
+		return $dateString;
 	}
 }

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -770,7 +770,7 @@ class Post_Command extends CommandWithDBObject {
 		if ( $date && $date->format( 'Y-m-d' ) === $post_data['post_date'] ) {
 			$post_data['post_date'] .= ' 00:00:00';
 		}
-		
+
 		$date_gmt = DateTime::createFromFormat( 'Y-m-d', $post_data['post_date_gmt'] );
 		if ( $date_gmt && $date_gmt->format( 'Y-m-d' ) === $post_data['post_date_gmt'] ) {
 			$post_data['post_date_gmt'] .= ' 00:00:00';

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -1003,18 +1003,18 @@ class Post_Command extends CommandWithDBObject {
 	/**
 	 * Convert a date-time string with a hyphen separator to a space separator.
 	 * 
-	 * @param string $dateString The date-time string to convert.
+	 * @param string $date_string The date-time string to convert.
 	 * @return string The converted date-time string.
 	 * 
 	 * Example:
-	 * maybeConvertHyphenatedDateFormat("2018-07-05-17:17:17");
+	 * maybe_convert_hyphenated_date_format( "2018-07-05-17:17:17" );
 	 * Returns: "2018-07-05 17:17:17"
 	 */
-	private function maybe_convert_hyphenated_date_format($dateString) {
-		// Check if the date string matches the format with the hyphen between date and time
-		if (preg_match('/^(\d{4}-\d{2}-\d{2})-(\d{2}:\d{2}:\d{2})$/', $dateString, $matches)) {
+	private function maybe_convert_hyphenated_date_format( $date_string ) {
+		// Check if the date string matches the format with the hyphen between date and time.
+		if ( preg_match( '/^(\d{4}-\d{2}-\d{2})-(\d{2}:\d{2}:\d{2})$/', $date_string, $matches ) ) {
 			return $matches[1] . ' ' . $matches[2];
 		}
-		return $dateString;
+		return $date_string;
 	}
 }

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -764,18 +764,19 @@ class Post_Command extends CommandWithDBObject {
 		$post_data['post_date']     = $this->maybe_convert_hyphenated_date_format( $post_data['post_date'] );
 		$post_data['post_date_gmt'] = $this->maybe_convert_hyphenated_date_format( $post_data['post_date_gmt'] );
 
-		$date = DateTime::createFromFormat('Y-m-d', $post_data['post_date']);
+		// Add time if the string is a valid date without time.
+		$date = DateTime::createFromFormat( 'Y-m-d', $post_data['post_date'] );
 		$date = DateTime::createFromFormat( 'Y-m-d', $post_data['post_date'] );
 		if ( $date && $date->format( 'Y-m-d' ) === $post_data['post_date'] ) {
 			$post_data['post_date'] .= ' 00:00:00';
 		}
-
+		
 		$date_gmt = DateTime::createFromFormat( 'Y-m-d', $post_data['post_date_gmt'] );
 		if ( $date_gmt && $date_gmt->format( 'Y-m-d' ) === $post_data['post_date_gmt'] ) {
 			$post_data['post_date_gmt'] .= ' 00:00:00';
 		}
 
-		// Handle edge cases for how WP handle dates on wp_insert_post for older versions. If one of the values is empty, it's assigned to the current time.
+		// In older WordPress versions, wp_insert_post post dates default to the current time when a value is absent. We need to send a value for post_date_gmt if post_date is set and vice versa.
 		if ( ! empty( $post_data['post_date'] ) && empty( $post_data['post_date_gmt'] ) ) {
 			$post_data['post_date_gmt'] = get_gmt_from_date( $post_data['post_date'] );
 		}

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -764,15 +764,24 @@ class Post_Command extends CommandWithDBObject {
 		$post_data['post_date']     = $this->maybe_convert_hyphenated_date_format( $post_data['post_date'] );
 		$post_data['post_date_gmt'] = $this->maybe_convert_hyphenated_date_format( $post_data['post_date_gmt'] );
 
-		// Handle edge cases for how WP handle dates on wp_insert_post for older versions. If one of the values is empty, it's assigned to the current time. We need to avoid sending an empty value.
+		$date = DateTime::createFromFormat('Y-m-d', $post_data['post_date']);
+		$date = DateTime::createFromFormat( 'Y-m-d', $post_data['post_date'] );
+		if ( $date && $date->format( 'Y-m-d' ) === $post_data['post_date'] ) {
+			$post_data['post_date'] .= ' 00:00:00';
+		}
+
+		$date_gmt = DateTime::createFromFormat( 'Y-m-d', $post_data['post_date_gmt'] );
+		if ( $date_gmt && $date_gmt->format( 'Y-m-d' ) === $post_data['post_date_gmt'] ) {
+			$post_data['post_date_gmt'] .= ' 00:00:00';
+		}
+
+		// Handle edge cases for how WP handle dates on wp_insert_post for older versions. If one of the values is empty, it's assigned to the current time.
 		if ( ! empty( $post_data['post_date'] ) && empty( $post_data['post_date_gmt'] ) ) {
-			$only_date = strlen($post_data['post_date']) === 10;
-			$post_data['post_date_gmt'] = get_gmt_from_date( $post_data['post_date'], $only_date ? 'Y-m-d' : 'Y-m-d H:i:s' );
+			$post_data['post_date_gmt'] = get_gmt_from_date( $post_data['post_date'] );
 		}
 
 		if ( ! empty( $post_data['post_date_gmt'] ) && empty( $post_data['post_date'] ) ) {
-			$only_date = strlen($post_data['post_date_gmt']) === 10;
-			$post_data['post_date'] = get_date_from_gmt( $post_data['post_date_gmt'], $only_date ? 'Y-m-d' : 'Y-m-d H:i:s' );
+			$post_data['post_date'] = get_date_from_gmt( $post_data['post_date_gmt'] );
 		}
 
 		if ( ! post_type_exists( $post_data['post_type'] ) ) {

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -764,6 +764,15 @@ class Post_Command extends CommandWithDBObject {
 		$post_data['post_date']     = $this->maybe_convert_hyphenated_date_format( $post_data['post_date'] );
 		$post_data['post_date_gmt'] = $this->maybe_convert_hyphenated_date_format( $post_data['post_date_gmt'] );
 
+		// Handle edge cases for how WP handle dates on wp_insert_post for older versions. If one of the values is empty, it's assigned to the current time. We need to avoid sending an empty value.
+		if ( isset( $post_data['post_date'] ) && empty( $post_data['post_date_gmt'] ) ) {
+			$post_data['post_date_gmt'] = get_gmt_from_date( $post_data['post_date'] );
+		}
+		
+		if ( isset( $post_data['post_date_gmt'] ) && empty( $post_data['post_date'] ) ) {
+			$post_data['post_date'] = get_date_from_gmt( $post_data['post_date_gmt'] );
+		}
+
 		if ( ! post_type_exists( $post_data['post_type'] ) ) {
 			WP_CLI::error( "'{$post_data['post_type']}' is not a registered post type." );
 		}


### PR DESCRIPTION
This PR uses an empty string as the default value for the `--post_date` and `--post_date_gmt` parameters of `wp generate posts`. 
This will align with the behavior of `wp_insert_post` and use the current time for the generated posts when a date is not provided. If a date is provided, it's passed down to `wp_insert_post`.
